### PR TITLE
Make TNGFile.seek raise the expected error

### DIFF
--- a/pytng/pytng.pyx
+++ b/pytng/pytng.pyx
@@ -273,6 +273,8 @@ cdef class TNGFile:
         step : int
            desired frame number
         """
+        if self.mode == 'w':
+            raise IOError("seek not allowed in write mode")
         if self.is_open:
             if step < 0:
                 step += len(self)
@@ -281,7 +283,7 @@ cdef class TNGFile:
 
             self.step = step
         else:
-            raise IOError("seek not allowed in write mode")
+            raise IOError('No file currently opened')
 
     def __getitem__(self, frame):
         cdef int64_t start, stop, step, i

--- a/tests/test_tng.py
+++ b/tests/test_tng.py
@@ -113,10 +113,29 @@ def test_last_positions(GMX_REF_DATA, GMX_REF_FILEPATH):
 
 
 @pytest.mark.parametrize('idx', [-11, -12, 10, 11])
-def test_seek_IOError(idx, GMX_REF_FILEPATH):
+def test_seek_IndexError(idx, GMX_REF_FILEPATH):
     with pytng.TNGFile(GMX_REF_FILEPATH, 'r') as tng:
         with pytest.raises(IndexError):
             tng[idx]
+
+
+# An exception is raised because the file does not exist (see issue #10).
+# Using an existing file instead would fix the issue, but would also empty
+# the file therefore breaking subsequent tests.
+@pytest.mark.skip(reason="An other issue interfere, see issue #10")
+def test_seek_write(MISSING_FILEPATH):
+    with pytng.TNGFile(MISSING_FILEPATH, mode='w') as tng:
+        with pytest.raises(IOError) as excinfo:
+            tng.seek(0)
+        assert "seek not allowed in write mode" in str(excinfo.value)
+
+
+def test_seek_not_open(GMX_REF_FILEPATH):
+    with pytng.TNGFile(GMX_REF_FILEPATH) as tng:
+        pass
+    with pytest.raises(IOError) as excinfo:
+        tng.seek(0)
+    assert 'No file currently opened' in str(excinfo.value)
 
 
 def test_time(GMX_REF_DATA, GMX_REF_FILEPATH):


### PR DESCRIPTION
Fixes #11

The message attached to the exception raised by TNGFile.seek when a file
is opened in write mode is now consistent with what happens. The same
goes for the message for the exception raised when seeking on a non-open
file.

The test for the message about write mode is skipped at the moment
because of #10.