### PR TITLE
Fixing TNG iteration

### DIFF
--- a/pytng/pytng.pyx
+++ b/pytng/pytng.pyx
@@ -155,17 +155,12 @@ cdef class TNGFile:
     def __cinit__(self, fname, mode='r'):
         self.fname = fname
         self._n_frames = -1
-        # initialise what blocks we care about
-        # TODO: One day make this customisable
-        self.blocks = 2
-        self.block_ids = <int64_t*>malloc(sizeof(int64_t) * 2)
-        self.block_ids[0] = TNG_TRAJ_BOX_SHAPE
-        self.block_ids[1] = TNG_TRAJ_POSITIONS
-        self.last_frame = -1
+        self.block_ids = NULL
         self.open(self.fname, mode)
 
     def __dealloc__(self):
-        free(self.block_ids)
+        if not self.block_ids == NULL:
+            free(self.block_ids)
         self.close()
 
     cdef int64_t _get_nframes(self):
@@ -230,6 +225,13 @@ cdef class TNGFile:
         mode : str
            mode to open the file in, 'r' for read, 'w' for write
         """
+        self.last_frame = -1
+        # initialise what blocks we care about
+        # TODO: One day make this customisable
+        self.blocks = 2
+        self.block_ids = <int64_t*>malloc(sizeof(int64_t) * 2)
+        self.block_ids[0] = TNG_TRAJ_BOX_SHAPE
+        self.block_ids[1] = TNG_TRAJ_POSITIONS
         self.mode = mode
 
         cdef char _mode

--- a/pytng/pytng.pyx
+++ b/pytng/pytng.pyx
@@ -24,6 +24,9 @@ ctypedef enum tng_data_type: TNG_CHAR_DATA, TNG_INT_DATA, TNG_FLOAT_DATA, TNG_DO
 ctypedef enum tng_hash_mode: TNG_SKIP_HASH, TNG_USE_HASH
 
 cdef long long TNG_TRAJ_BOX_SHAPE = 0x0000000010000000LL
+cdef long long TNG_TRAJ_POSITIONS = 0x0000000010000001LL
+cdef long long TNG_TRAJ_VELOCITIES = 0x0000000010000002LL
+cdef long long TNG_TRAJ_FORCES = 0x0000000010000003LL
 
 status_error_message = ['OK', 'Failure', 'Critical']
 
@@ -85,6 +88,16 @@ cdef extern from "tng/tng_io.h":
     tng_function_status tng_num_frame_sets_get(
         const tng_trajectory_t tng_data,
         int64_t* n)
+
+    tng_function_status tng_util_trajectory_next_frame_present_data_blocks_find(
+        const tng_trajectory_t tng_data,
+        int64_t current_frame,
+        const int64_t n_requested_data_block_ids,
+        const int64_t *requested_data_block_ids,
+        int64_t *next_frame,
+        int64_t *n_data_blocks_in_next_frame,
+        int64_t **data_block_ids_in_next_frame)
+
 
 TNGFrame = namedtuple("TNGFrame", "positions time step box")
 

--- a/pytng/src/lib/tng_io.c
+++ b/pytng/src/lib/tng_io.c
@@ -11193,8 +11193,9 @@ tng_function_status DECLSPECDLLEXPORT tng_frame_set_of_frame_find
 
     /* Take long steps forward until a long step forward would be too long or
      * the right frame set is found */
-    while(file_pos > 0 && first_frame + long_stride_length *
-          n_frames_per_frame_set <= frame)
+    while(file_pos > 0 &&
+	  frame_set->long_stride_next_frame_set_file_pos > 0 &&
+	  first_frame + long_stride_length * n_frames_per_frame_set <= frame)
     {
         file_pos = frame_set->long_stride_next_frame_set_file_pos;
         if(file_pos > 0)
@@ -11228,8 +11229,9 @@ tng_function_status DECLSPECDLLEXPORT tng_frame_set_of_frame_find
 
     /* Take medium steps forward until a medium step forward would be too long
      * or the right frame set is found */
-    while(file_pos > 0 && first_frame + medium_stride_length *
-          n_frames_per_frame_set <= frame)
+    while(file_pos > 0 &&
+	  frame_set->medium_stride_next_frame_set_file_pos > 0 &&
+	  first_frame + medium_stride_length * n_frames_per_frame_set <= frame)
     {
         file_pos = frame_set->medium_stride_next_frame_set_file_pos;
         if(file_pos > 0)
@@ -11264,7 +11266,10 @@ tng_function_status DECLSPECDLLEXPORT tng_frame_set_of_frame_find
     }
 
     /* Take one step forward until the right frame set is found */
-    while(file_pos > 0 && first_frame < frame && last_frame < frame)
+    while(file_pos > 0 &&
+	  frame_set->next_frame_set_file_pos > 0 &&
+	  first_frame < frame &&
+	  last_frame < frame)
     {
         file_pos = frame_set->next_frame_set_file_pos;
         if(file_pos > 0)
@@ -11300,8 +11305,9 @@ tng_function_status DECLSPECDLLEXPORT tng_frame_set_of_frame_find
 
     /* Take long steps backward until a long step backward would be too long
      * or the right frame set is found */
-    while(file_pos > 0 && first_frame - long_stride_length *
-          n_frames_per_frame_set >= frame)
+    while(file_pos > 0 &&
+	  frame_set->long_stride_prev_frame_set_file_pos > 0 &&
+	  first_frame - long_stride_length * n_frames_per_frame_set >= frame)
     {
         file_pos = frame_set->long_stride_prev_frame_set_file_pos;
         if(file_pos > 0)
@@ -11337,8 +11343,9 @@ tng_function_status DECLSPECDLLEXPORT tng_frame_set_of_frame_find
 
     /* Take medium steps backward until a medium step backward would be too long
      * or the right frame set is found */
-    while(file_pos > 0 && first_frame - medium_stride_length *
-          n_frames_per_frame_set >= frame)
+    while(file_pos > 0 &&
+	  frame_set->medium_stride_prev_frame_set_file_pos > 0 &&
+	  first_frame - medium_stride_length * n_frames_per_frame_set >= frame)
     {
         file_pos = frame_set->medium_stride_prev_frame_set_file_pos;
         if(file_pos > 0)
@@ -11373,7 +11380,9 @@ tng_function_status DECLSPECDLLEXPORT tng_frame_set_of_frame_find
     }
 
     /* Take one step backward until the right frame set is found */
-    while(file_pos > 0 && first_frame > frame && last_frame > frame)
+    while(file_pos > 0 &&
+	  frame_set->prev_frame_set_file_pos > 0 &&
+	  first_frame > frame && last_frame > frame)
     {
         file_pos = frame_set->prev_frame_set_file_pos;
         if(file_pos > 0)


### PR DESCRIPTION
So it looks like the `pos_read_range` function expects frame numbers in terms of the global MD step counter, rather than relative to the number of frames.

This seems to start to fix TNG file reading....