### PR TITLE
remove PEP8 check (plugin no longer supported)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ branches:
 
 install:
   - pip install --upgrade pytest
-  - pip install codecov pytest-cov pytest-pep8
+  - pip install codecov pytest-cov
   - pip install --upgrade numpy cython
   - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install --upgrade sphinx sphinx-sitemap; fi
   - pip install -e .
 
 script:
-  - py.test -v --cov pytng --pep8 pytng tests
+  - pytest -v --cov pytng pytng tests
 
 after_success:
   - codecov


### PR DESCRIPTION
- fix #39
- PEP8 plugin 1.0.6 (latest from 2014) makes use of API that is no longer supported in pytest >= 6.0