### PR TITLE
update travis badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 pytng - A python library to read TNG files!
 ===========================================
 
-.. image:: https://travis-ci.org/MDAnalysis/pytng.svg?branch=master
-   :target: https://travis-ci.org/MDAnalysis/pytng
+.. image:: https://travis-ci.com/MDAnalysis/pytng.svg?branch=master
+  :target: https://travis-ci.com/MDAnalysis/pytng
 .. image:: https://codecov.io/gh/MDAnalysis/pytng/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/MDAnalysis/pytng
 


### PR DESCRIPTION
- part of #53 
- badge points to travis-ci.com now (was travis-ci.org)