### PR TITLE
BLD: build wheels against NumPy 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,7 @@ requires = [
     "versioningit",
     "wheel",
     # below matches MDA
-    "numpy==1.22.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.3; python_version=='3.10' and platform_python_implementation != 'PyPy'",
-    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-    "numpy==1.26.0; python_version=='3.12' and platform_python_implementation != 'PyPy'",
-    "numpy<2.0; python_version>='3.13'",
+    "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
* Related to https://github.com/MDAnalysis/mdanalysis/pull/4620.

* See discussion above for details, but in short we should build our wheels against NumPy `2.0.0` so that we have binaries that are runtime-compatible with both NumPy 1.x and 2.x series.

* Even if "we" don't do a release soon, I believe this may be helpful since we could then point the MDAnalysis CI at this github repo for `pytng` "no binary" build from source with NumPy 2.x, rather than disabling `pytng` testing over there.